### PR TITLE
"Sell" command now part of the general call

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,16 +1,16 @@
 import {
+  autosell,
+  autosellPrice,
+  cliExecute,
   Item,
   itemAmount,
   mallPrice,
-  putShop,
-  wellStocked,
-  autosellPrice,
-  autosell,
-  putDisplay,
-  use,
   print,
   putCloset,
-  cliExecute,
+  putDisplay,
+  putShop,
+  use,
+  wellStocked,
 } from "kolmafia";
 import { Kmail } from "libram";
 import { Options } from "./options";

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,7 +104,7 @@ function tabString(tab: Tab): string {
   return options.empty() ? title : `${title} with ${options}`;
 }
 
-export function main(args = "closet use mall autosell display kmail fuel"): void {
+export function main(args = "closet use mall autosell display sell kmail fuel"): void {
   cliExecute("refresh inventory");
   const tabs = favoriteTabs();
   const commands: TabTitle[] = args.split(" ").filter(isTabTitle);


### PR DESCRIPTION
"sell" wasn't executed when keeping-tabs was run without any arguments.

This was tested on the quick in my own setup, works here.