### PR TITLE
Correctly decide whether to mallsell or autosell

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -46,7 +46,7 @@ export const actions: {
   sell: (options: Options) => {
     return {
       action: (item: Item) => {
-        if (wellStocked(`${item}`, 1000, Math.min(100, autosellPrice(item) * 2))) {
+        if (wellStocked(`${item}`, 1000, Math.max(100, autosellPrice(item) * 2))) {
           autosell(amount(item, options), item);
         } else {
           putShop(0, 0, amount(item, options), item);


### PR DESCRIPTION
The script currently uses the wellStocked() function to decide whether to autosell or mall sell an item but to do that it needs to know the lowest allowed price in the mall which should be max(100, autosellPrice(item) * 2) but it previously calculated the min of these values instead. This commit changes it to max as it should be.

There's a wishlist request for this functionality that could be closed.