### PR TITLE
Add `low` action to list items with mallPrice

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ Naming a tab involves specifying what to do with all items in that tab by naming
 ### Actions
 
 * `mall`
-  * This will add the item to your mall store
+  * This will add the item to your mall store at the maximum possible price
+* `low`
+  * This will add the item to your mall store at the 5th lowest price currently listed
 * `autosell`
   * This will autosell the item
 * `sell`
-  * This will either autosell the item or add it to your mall store. It will add it to your mall store only if there are less than 1000 stocked at autosell price
+  * This will either autosell the item or add it to your mall store at the maximum possible price. It will add it to your mall store only if there are less than 1000 stocked at autosell price
 * `use`
   * This will use the item
 * `display`
@@ -132,7 +134,8 @@ Use `keeping-tabs debug help` to see a full list of available debug commands.
 
 ## TODO
 
-* [ ] Add more mall options (add at fixed price, add at min price, limit the items for sale)
+* [ ] Add more mall options (add at fixed price, limit the items for sale)
+* [x] Add more mall options (add at min price)
 * [ ] Add confirmation for kmailing, optionally?
 * [x] Add option to keep certain number of items (using format of keepN)
 * [ ] Add `pull` to pull specific items from Hagnks

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -54,6 +54,13 @@ export const actions: {
       },
     };
   },
+  low: options => {
+    return {
+      action: item => {
+        putShop(mallPrice(item), 0, amount(item, options), item);
+      }
+    };
+  },
   display: (options: Options) => {
     return { action: (item: Item) => putDisplay(amount(item, options), item) };
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ import { Options } from "./options";
 import { actions, filters } from "./actions";
 
 const HIGHLIGHT = isDarkMode() ? "yellow" : "blue";
-const DEFAULT_ACTIONS = "closet use mall autosell display sell kmail fuel collection";
+const DEFAULT_ACTIONS = "closet use mall autosell display sell kmail fuel collection low";
 
 function items(tabId: TabId, type: InventoryType): Item[] {
   const tab = visitUrl(`${type}.php?which=f${tabId}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export const ALL_TAB_TITLES = [
   "closet",
   "fuel",
   "collection",
+  "low",
 ] as const;
 export type TabTitle = typeof ALL_TAB_TITLES[number];
 export type TabId = number;


### PR DESCRIPTION
This commit adds a new action `low` that will list the item using kolMafia's mallPrice function. Other changes include:
- Adding low to the DEFAULT_ACTIONS string for reference in the help
- Updating the readme to clarify various malling options and update TODO list.

**_NEEDS TESTING!_** Tested myself by manually editing the release `keeping-tabs.js` file, but I'm not sure how to turn the pre-build TypeScript files into a single testable script.