### PR TITLE
Avoid unnecessary mall searches

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -46,10 +46,12 @@ export const actions: {
   sell: (options: Options) => {
     return {
       action: (item: Item) => {
-        if (wellStocked(`${item}`, 1000, Math.max(100, autosellPrice(item) * 2))) {
-          autosell(amount(item, options), item);
-        } else {
-          putShop(0, 0, amount(item, options), item);
+        if (amount(item, options) > 0) {
+          if (wellStocked(`${item}`, 1000, Math.max(100, autosellPrice(item) * 2))) {
+            autosell(amount(item, options), item);
+          } else {
+            putShop(0, 0, amount(item, options), item);
+          }
         }
       },
     };


### PR DESCRIPTION
If you have items (e.g. equipment) set to sell but keep 1 (or more), keeping tabs will do a mall search for each to determine whether the item should be autosold or put in the mall, even if none would actually be sold. This patch avoids those unnecessary mall searches.