### PR TITLE
autosell untradables added to a sell filter

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -46,7 +46,10 @@ export const actions: {
   sell: (options: Options) => {
     return {
       action: (item: Item) => {
-        if (wellStocked(`${item}`, 1000, Math.max(100, autosellPrice(item) * 2))) {
+        if (
+          wellStocked(`${item}`, 1000, Math.max(100, autosellPrice(item) * 2)) ||
+          !item.tradeable
+        ) {
           autosell(amount(item, options), item);
         } else {
           putShop(0, 0, amount(item, options), item);


### PR DESCRIPTION
currently keeeping tabs wont do anything to untradeable (but discardable) items added to a "sell" filter due to there not being 1000 items at mall min - added an or statment to fix this. 